### PR TITLE
Use `css-paint-polyfill` for Firefox and Safari

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -13,6 +13,7 @@
         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
         <h2>With Houdini!</h2>
         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+        <script src="https://unpkg.com/css-paint-polyfill"></script>
         <script src="../modularscale-css.js"></script>
     </body>
 </html>


### PR DESCRIPTION
This polyfill is recommended by https://houdini.how/usage/ and adds support for Firefox and Safari.

If you'd like to use ES modules, see [nickmccurdy:polyfill-modules](https://github.com/modularscale/modularscale-css/compare/master...nickmccurdy:modularscale-css:polyfill-modules) instead. Note that this requires using a bundler or server for local development, and would also mean consumers would need ES module support.